### PR TITLE
Fix #15, `mantra create` now gracefully handles error

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -38,7 +38,12 @@ function executeCommand(cmd, options) {
 function createMeteorApp(appName) {
   let appPath = `./${appName}`;
 
-  executeCommand(`meteor create ${appName} --release 1.3-beta.11`);
+  try {
+    executeCommand(`meteor create ${appName} --release 1.3-beta.11`);
+  } catch(e) {
+    logger.error(`Failed to create ${appName}`);
+    process.exit(1);
+  }
   execSync('rm *.css *.html *.js', {cwd: appPath});
   execSync(`echo 'kadira:flow-router' >> ${appPath}/.meteor/packages`);
   execSync(`echo 'aldeed:collection2' >> ${appPath}/.meteor/packages`);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,4 @@
-import {green, yellow, cyan} from 'colors';
+import {green, yellow, cyan, red} from 'colors';
 
 export const logger = {
   create(msg) {
@@ -12,5 +12,8 @@ export const logger = {
   },
   run(msg) {
     console.log(green(`  run  `) + msg);
+  },
+  error(msg) {
+    console.log(red(`  error  `) + msg);
   }
 };


### PR DESCRIPTION
- Added `error` with colour red in `logger` object.
- Use `logger.error` if getting an error in `mantra create`.
