### PR TITLE
Remove nested ul tag from p tag due to warning in Chrome

### DIFF
--- a/templates/client/modules/core/components/home.jsx
+++ b/templates/client/modules/core/components/home.jsx
@@ -6,16 +6,14 @@ const Home = () => (
     <p>
       Welcome to Mantra 0.2.0.
     </p>
-    <p>
-      <ul>
-        <li>
-          Read <a target="_blank" href="https://kadirahq.github.io/mantra/">spec</a>
-        </li>
-        <li>
-          Learn <a target="_blank" href="https://github.com/sungwoncho/mantra-cli#commands">CLI</a>
-        </li>
-      </ul>
-    </p>
+    <ul>
+      <li>
+        Read <a target="_blank" href="https://kadirahq.github.io/mantra/">spec</a>
+      </li>
+      <li>
+        Learn <a target="_blank" href="https://github.com/sungwoncho/mantra-cli#commands">CLI</a>
+      </li>
+    </ul>
   </div>
 );
 


### PR DESCRIPTION
Warning: validateDOMNesting(...): <ul> cannot appear as a descendant of <p>. See Home > p > ... > ul.
