### PR TITLE
Update to use 1.3 release

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -20,7 +20,7 @@ export default function create(appPath, options) {
     logger.invoke('init');
     shelljs.set('-e');
     let currentPath = shelljs.pwd();
-    shelljs.exec(`meteor create ${appPath} --release 1.3-rc.1`, {silent: !options.verbose});
+    shelljs.exec(`meteor create ${appPath}`, {silent: !options.verbose});
     shelljs.cd(appPath);
     shelljs.rm('-rf', ['client', 'server']);
     `kadira:flow-router${lineBreak}`.toEnd('.meteor/packages');


### PR DESCRIPTION
Meteor 1.3 has been announce so we no longer need to specify the release

http://info.meteor.com/blog/announcing-meteor-1.3
