### PR TITLE
Bug fix: rule jsx-uses-vars is needed.

### DIFF
--- a/templates/eslintrc.tt
+++ b/templates/eslintrc.tt
@@ -187,6 +187,7 @@
     "wrap-iife": 2,
     "wrap-regex": 0,
     "yoda": [2, "never", {"exceptRange": true}],
-    "react/jsx-uses-react": 1
+    "react/jsx-uses-react": 1,
+    "react/jsx-uses-vars": 1
   }
 }


### PR DESCRIPTION
This is a bug fixation.

Without specifying rule [`jsx-uses-vars`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md), ESLint 2.7.x will consider the following code to be invalid:

``` jsx
import React from 'react';
import { MyComponent } from './component.jsx';

export default () => (
  <MyComponent />
);
```
