### PR TITLE
Component class template preference

### DIFF
--- a/templates/client/modules/core/components/generic_class.tt
+++ b/templates/client/modules/core/components/generic_class.tt
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, {Component} from 'react';
 
-class <%= componentName %> extends React.Component {
+export default class <%= componentName %> extends Component {
   render() {
     return (
       <div>
@@ -9,5 +9,3 @@ class <%= componentName %> extends React.Component {
     );
   }
 }
-
-export default <%= componentName %>;

--- a/templates/client/modules/core/components/generic_class.tt
+++ b/templates/client/modules/core/components/generic_class.tt
@@ -1,6 +1,6 @@
-import React, {Component} from 'react';
+import React from 'react';
 
-export default class <%= componentName %> extends Component {
+export default class <%= componentName %> extends React.Component {
   render() {
     return (
       <div>

--- a/templates/client/modules/core/components/generic_stateless.tt
+++ b/templates/client/modules/core/components/generic_stateless.tt
@@ -1,9 +1,7 @@
 import React from 'react';
 
-const <%= componentName %> = () => (
+export default () => (
   <div>
     <%= componentName %>
   </div>
 );
-
-export default <%= componentName %>;


### PR DESCRIPTION
First of all, thank you for your work with this CLI!

I have made two changes:
1. A named import of Component in order to strip React. from React.Component
2. Combined the class definition with the class export

Perhaps something worth considering? I made the pull request mainly because of point 2, which i find very attractive.
