### PR TITLE
Add a .gitkeep file to add empty but required folders to git

### DIFF
--- a/lib/generators/module.js
+++ b/lib/generators/module.js
@@ -3,31 +3,22 @@ import _ from 'lodash';
 import {createDir, createFile, insertToFile} from '../utils';
 import {removeFile, removeWholeLine} from './utils';
 import {logger} from '../logger';
+import {mkdirsSync} from 'fs-extra';
 
 export function generateModule(name) {
   let snakeCaseName = _.snakeCase(name);
 
-  createDir(`./client/modules/${snakeCaseName}`);
-  createDir(`./client/modules/${snakeCaseName}/components`);
-  createDir(`./client/modules/${snakeCaseName}/containers`);
-  createDir(`./client/modules/${snakeCaseName}/configs`);
-  createDir(`./client/modules/${snakeCaseName}/libs`);
+  mkdirsSync(`./client/modules/${snakeCaseName}`);
+  mkdirsSync(`./client/modules/${snakeCaseName}/components`);
+  mkdirsSync(`./client/modules/${snakeCaseName}/containers`);
+  mkdirsSync(`./client/modules/${snakeCaseName}/configs`);
+  mkdirsSync(`./client/modules/${snakeCaseName}/libs`);
   createFile(`${__dirname}/../../templates/client/modules/core/actions/index.js`,
     `client/modules/${snakeCaseName}/actions/index.js`);
   createFile(`${__dirname}/../../templates/client/modules/core/index.js`,
     `client/modules/${snakeCaseName}/index.js`);
   createFile(`${__dirname}/../../templates/client/modules/core/routes.tt`,
     `client/modules/${snakeCaseName}/routes.jsx`);
-
-  // Git keep files to make sure the folders stay
-  createFile(`${__dirname}/../../templates/client/modules/core/.gitkeep`,
-    `./client/modules/${snakeCaseName}/components/.gitkeep`);
-  createFile(`${__dirname}/../../templates/client/modules/core/.gitkeep`,
-    `./client/modules/${snakeCaseName}/containers/.gitkeep`);
-  createFile(`${__dirname}/../../templates/client/modules/core/.gitkeep`,
-    `./client/modules/${snakeCaseName}/configs/.gitkeep`);
-  createFile(`${__dirname}/../../templates/client/modules/core/.gitkeep`,
-    `./client/modules/${snakeCaseName}/libs/.gitkeep`);
 
   // Modify client/main.js to import and load the newly generated module
   insertToFile('./client/main.js',

--- a/lib/generators/module.js
+++ b/lib/generators/module.js
@@ -19,6 +19,16 @@ export function generateModule(name) {
   createFile(`${__dirname}/../../templates/client/modules/core/routes.tt`,
     `client/modules/${snakeCaseName}/routes.jsx`);
 
+  // Git keep files to make sure the folders stay
+  createFile(`${__dirname}/../../templates/client/modules/core/.gitkeep`,
+    `./client/modules/${snakeCaseName}/components/.gitkeep`);
+  createFile(`${__dirname}/../../templates/client/modules/core/.gitkeep`,
+    `./client/modules/${snakeCaseName}/containers/.gitkeep`);
+  createFile(`${__dirname}/../../templates/client/modules/core/.gitkeep`,
+    `./client/modules/${snakeCaseName}/configs/.gitkeep`);
+  createFile(`${__dirname}/../../templates/client/modules/core/.gitkeep`,
+    `./client/modules/${snakeCaseName}/libs/.gitkeep`);
+
   // Modify client/main.js to import and load the newly generated module
   insertToFile('./client/main.js',
   `import ${snakeCaseName}Module from './modules/${snakeCaseName}';`,

--- a/lib/generators/module.js
+++ b/lib/generators/module.js
@@ -3,16 +3,15 @@ import _ from 'lodash';
 import {createDir, createFile, insertToFile} from '../utils';
 import {removeFile, removeWholeLine} from './utils';
 import {logger} from '../logger';
-import {mkdirsSync} from 'fs-extra';
 
 export function generateModule(name) {
   let snakeCaseName = _.snakeCase(name);
 
-  mkdirsSync(`./client/modules/${snakeCaseName}`);
-  mkdirsSync(`./client/modules/${snakeCaseName}/components`);
-  mkdirsSync(`./client/modules/${snakeCaseName}/containers`);
-  mkdirsSync(`./client/modules/${snakeCaseName}/configs`);
-  mkdirsSync(`./client/modules/${snakeCaseName}/libs`);
+  createDir(`./client/modules/${snakeCaseName}`);
+  createDir(`./client/modules/${snakeCaseName}/components`);
+  createDir(`./client/modules/${snakeCaseName}/containers`);
+  createDir(`./client/modules/${snakeCaseName}/configs`);
+  createDir(`./client/modules/${snakeCaseName}/libs`);
   createFile(`${__dirname}/../../templates/client/modules/core/actions/index.js`,
     `client/modules/${snakeCaseName}/actions/index.js`);
   createFile(`${__dirname}/../../templates/client/modules/core/index.js`,

--- a/lib/generators/utils.js
+++ b/lib/generators/utils.js
@@ -305,7 +305,7 @@ export function _generate(type, moduleName, entityName, options) {
     return;
   }
 
-  fs.writeFileSync(outputPath, component);
+  fse.outputFileSync(outputPath, component);
   logger.create(outputPath);
 }
 


### PR DESCRIPTION
Hi, I just ran into a small issue when using mantra-cli. Hope I can help to solve it :-)

I work with a small team. Recently, my team mate generated a new model and added some code. He pushed his work to the repo. I pulled it and tried to add a new container to the module he created. I got some errors. After trying for some time I realized that the `containers` folder is missing. Since it's empty, it didn't get pushed to the repo. So, when I pulled, I didn't got that folder. I had to manually create it.

But if we add a empty file in the folder, it will get pushed to the repo. So, I added a empty file called `.gitkeep` (A standard practice) to the folders. Hope this is a good idea :-)
