### PR TITLE
add moduleName to template-variables

### DIFF
--- a/lib/generators/utils.js
+++ b/lib/generators/utils.js
@@ -132,13 +132,15 @@ function checkForCustomTemplate(config, entityType) {
  * @param fileName {String} - name of the file being generated
  * @return {Object} - key-values pairs of variable names and their values
  */
-export function getTemplateVaraibles(type, fileName, options = {}) {
+export function getTemplateVaraibles(type, moduleName, fileName, options = {}) {
   if (type === 'component') {
     return {
+      moduleName: _.snakeCase(moduleName),
       componentName: _.upperFirst(_.camelCase(fileName))
     };
   } else if (type === 'container') {
     return {
+      moduleName: _.snakeCase(moduleName),
       componentName: _.upperFirst(_.camelCase(fileName)),
       componentFileName: _.snakeCase(fileName)
     };
@@ -350,7 +352,7 @@ export function compileTemplate(content, variables, config) {
 export function _generate(type, moduleName, entityName, options, config) {
   let templateContent = readTemplateContent(type, options, config);
   let outputPath = getOutputPath(type, entityName, moduleName);
-  let templateVariables = getTemplateVaraibles(type, entityName, options);
+  let templateVariables = getTemplateVaraibles(type, moduleName, entityName, options);
   let component = compileTemplate(templateContent, templateVariables, config);
 
   if (checkFileExists(outputPath)) {

--- a/test/generators/utils_test.js
+++ b/test/generators/utils_test.js
@@ -117,23 +117,24 @@ describe("getOutputPath", function() {
 describe("getTemplateVaraibles", function() {
   describe("for components", function() {
     let expected = {
-      componentName: 'UserList'
+      componentName: 'UserList',
+      moduleName: 'core'
     };
 
     it("gets template variables - variation 1", function() {
-      let result = utils.getTemplateVaraibles('component', 'userList');
+      let result = utils.getTemplateVaraibles('component', 'core', 'userList');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 2", function() {
-      let result = utils.getTemplateVaraibles('component', 'user_list');
+      let result = utils.getTemplateVaraibles('component', 'core', 'user_list');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 3", function() {
-      let result = utils.getTemplateVaraibles('component', 'UserList');
+      let result = utils.getTemplateVaraibles('component', 'core', 'UserList');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
@@ -142,23 +143,24 @@ describe("getTemplateVaraibles", function() {
   describe("for containers", function() {
     let expected = {
       componentName: 'UserList',
-      componentFileName: 'user_list'
+      componentFileName: 'user_list',
+      moduleName: 'core'
     };
 
     it("gets template variables - variation 1", function() {
-      let result = utils.getTemplateVaraibles('container', 'userList');
+      let result = utils.getTemplateVaraibles('container', 'core', 'userList');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 2", function() {
-      let result = utils.getTemplateVaraibles('container', 'user_list');
+      let result = utils.getTemplateVaraibles('container', 'core', 'user_list');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 3", function() {
-      let result = utils.getTemplateVaraibles('container', 'UserList');
+      let result = utils.getTemplateVaraibles('container', 'core', 'UserList');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
@@ -171,31 +173,31 @@ describe("getTemplateVaraibles", function() {
     };
 
     it("gets template variables - variation 1", function() {
-      let result = utils.getTemplateVaraibles('collection', 'pullRequests');
+      let result = utils.getTemplateVaraibles('collection', null, 'pullRequests');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 2", function() {
-      let result = utils.getTemplateVaraibles('collection', 'pull_requests');
+      let result = utils.getTemplateVaraibles('collection', null, 'pull_requests');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 3", function() {
-      let result = utils.getTemplateVaraibles('collection', 'PullRequests');
+      let result = utils.getTemplateVaraibles('collection', null, 'PullRequests');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets templates variables with collection2 option", function() {
-      let result = utils.getTemplateVaraibles('collection', 'PullRequests', {schema: 'collection2'});
+      let result = utils.getTemplateVaraibles('collection', null, 'PullRequests', {schema: 'collection2'});
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets templates variables with astronomy option", function() {
-      let result = utils.getTemplateVaraibles('collection', 'PullRequests', {schema: 'astronomy'});
+      let result = utils.getTemplateVaraibles('collection', null, 'PullRequests', {schema: 'astronomy'});
       let matched = _.isEqual(result, {
         collectionName: 'PullRequests',
         collectionFileName: 'pull_requests',
@@ -212,19 +214,19 @@ describe("getTemplateVaraibles", function() {
     };
 
     it("gets template variables - variation 1", function() {
-      let result = utils.getTemplateVaraibles('method', 'pullRequests');
+      let result = utils.getTemplateVaraibles('method', null, 'pullRequests');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 2", function() {
-      let result = utils.getTemplateVaraibles('method', 'pull_requests');
+      let result = utils.getTemplateVaraibles('method', null, 'pull_requests');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 3", function() {
-      let result = utils.getTemplateVaraibles('method', 'PullRequests');
+      let result = utils.getTemplateVaraibles('method', null, 'PullRequests');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
@@ -237,19 +239,19 @@ describe("getTemplateVaraibles", function() {
     };
 
     it("gets template variables - variation 1", function() {
-      let result = utils.getTemplateVaraibles('publication', 'pullRequests');
+      let result = utils.getTemplateVaraibles('publication', null, 'pullRequests');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 2", function() {
-      let result = utils.getTemplateVaraibles('publication', 'pull_requests');
+      let result = utils.getTemplateVaraibles('publication', null, 'pull_requests');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });
 
     it("gets template variables - variation 3", function() {
-      let result = utils.getTemplateVaraibles('publication', 'PullRequests');
+      let result = utils.getTemplateVaraibles('publication', null, 'PullRequests');
       let matched = _.isEqual(result, expected);
       expect(matched).to.equal(true);
     });


### PR DESCRIPTION
I want to create generators for storybook-stories in components.

A story begins with `storiesOf('module_name.ComponentName', module)`

so we need the module name available as template-variable.

This PR introduces these template-variables for components and stories.

Some things to discuss:
- I added the moduleName parameter as second parameter to getTemplateVaraibles, so that it is symetrical to getTestTemplateVaraibles. However, some generators do not have a moduleName (collections and publications), so this parameter is null there, which is a little bit ugly.
- i think we can merge the two functions getTestTemplateVaraibles and getTemplateVaraibles, because they do nearly the same (and can fix the typo in getTemplateVaraibles btw ;-) )
- The module-name is exposed in snake_case, as in getTestTemplateVaraibles, but I think its best to have both:

moduleName: CamelCaseModul
moduleFileName: snake_case_modul
