### PR TITLE
allow customization of test templates

### DIFF
--- a/lib/generators/utils.js
+++ b/lib/generators/utils.js
@@ -112,8 +112,7 @@ export function readTemplateContent(type, templateOptions, config) {
   // First, try to get custom template from config
   // If cannot find custom template, return the default
   if (checkForCustomTemplate(config, type, templateOptions)) {
-    let templateConfig = _.find(config.templates, {name: type});
-
+    let templateConfig = getCustomTemplate(config, type, templateOptions);
     return templateConfig.text;
   } else {
     let templatePath = getTemplatePath(type, templateOptions);
@@ -121,13 +120,21 @@ export function readTemplateContent(type, templateOptions, config) {
   }
 }
 
-function checkForCustomTemplate(config, entityType, {testTemplate = false}) {
+function getCustomTemplate(config, entityType, {testTemplate = false}) {
+  const selector = {name: entityType};
+  if(testTemplate) {
+    selector.test = true
+  }
+  const templateConfig = _.find(config.templates, selector);
+
+  return templateConfig;
+}
+function checkForCustomTemplate(config, entityType, options) {
   if (!config.templates) {
     return false;
   }
-  entityType = `${entityType}${testTemplate ? "-test" : ""}`
-  let customTemplateTypes = _.map(config.templates, 'name');
-  return customTemplateTypes.indexOf(entityType) > -1;
+  const template = getCustomTemplate(config, entityType, options);
+  return !_.isEmpty(template);
 }
 
 /**

--- a/lib/generators/utils.js
+++ b/lib/generators/utils.js
@@ -111,7 +111,7 @@ export function getTemplatePath(type, options = {}) {
 export function readTemplateContent(type, templateOptions, config) {
   // First, try to get custom template from config
   // If cannot find custom template, return the default
-  if (checkForCustomTemplate(config, type)) {
+  if (checkForCustomTemplate(config, type, templateOptions)) {
     let templateConfig = _.find(config.templates, {name: type});
 
     return templateConfig.text;
@@ -121,11 +121,11 @@ export function readTemplateContent(type, templateOptions, config) {
   }
 }
 
-function checkForCustomTemplate(config, entityType) {
+function checkForCustomTemplate(config, entityType, {testTemplate = false}) {
   if (!config.templates) {
     return false;
   }
-
+  entityType = `${entityType}${testTemplate ? "-test" : ""}`
   let customTemplateTypes = _.map(config.templates, 'name');
   return customTemplateTypes.indexOf(entityType) > -1;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantra-cli",
-  "version": "0.4.0-rc.2",
+  "version": "0.4.0-rc.3",
   "description": "Command line interface for building Meteor apps with Mantra",
   "bin": {
     "mantra": "./bin/mantra"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantra-cli",
-  "version": "0.4.0-rc.3",
+  "version": "0.4.0-rc.4",
   "description": "Command line interface for building Meteor apps with Mantra",
   "bin": {
     "mantra": "./bin/mantra"


### PR DESCRIPTION
fixes https://github.com/mantrajs/mantra-cli/issues/87

few notes:

test-templates can be configured with:

```
 - name: 'component'
    test: true
    text: |
      import .....

```

I also thought about using `name: 'component-test',
but i thought options would be better, as we could easily add more options (e.g. for variants like class instead of arrow function in components)

sidenote:

currently there are options for astronomy and collection2 scheme. I would deprecated these options in favor of better customization.
