### PR TITLE
Make sure that reactive-dict is added on create

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -31,6 +31,8 @@ export default function create(appPath, options = {}) {
     shelljs.cd(appPath);
     shelljs.rm('-rf', ['client', 'server']);
     `kadira:flow-router${lineBreak}`.toEnd('.meteor/packages');
+    shelljs.rm('-rf', ['client', 'server']);
+    `reactive-dict${lineBreak}`.toEnd('.meteor/packages');
     shelljs.cd(currentPath);
   }
 


### PR DESCRIPTION
reactive-dict is a package needed by Mantra for LocalState, but wasn't added by default like Flow Router. This should fix that.