### PR TITLE
improve support for non-meteor-projects

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,12 +1,20 @@
+## Next
+
+new options that help usage in non-meteor projects (e.g. react native). Here with the defaults:
+
+- `storiesFolder: .stories`: foldername for storybook files. Some projects don't like the dot in the foldername, so you can change that here.
+- `jsxExtension: jsx`: change to js in react-native apps.
+- `snakeCaseFileNames: true`, if false, component-files etc. are created with PascalCase or camelCase (e.g. actions)
+
 ## 0.5.1 (May 2017)
 
-* Add option `modulesPath` to specify the folder where mantra-modules are created (defaults to client/modules). 
-You can set `modulesPath: imports/modules` to prevent meteor from eagerly load modules. This is needed if you 
+* Add option `modulesPath` to specify the folder where mantra-modules are created (defaults to client/modules).
+You can set `modulesPath: imports/modules` to prevent meteor from eagerly load modules. This is needed if you
 use codesplitting in meteor 1.5. ([@macrozone](https://github.com/macrozone))
 
 ## 0.4.6 (February 24 2017)
 
-* Add options generateComponentTests and generateContainerTests that allows to specify whether 
+* Add options generateComponentTests and generateContainerTests that allows to specify whether
 component unit tests should be created (defaults to true) ([@macrozone](https://github.com/macrozone))
 
 ## 0.4.5 (November 30 2016)

--- a/lib/config_utils.js
+++ b/lib/config_utils.js
@@ -7,7 +7,10 @@ export const DEFAULT_CONFIG = {
   storybook: false,
   generateComponentTests: true,
   generateContainerTests: true,
-  modulesPath: 'client/modules'
+  modulesPath: 'client/modules',
+  snakeCaseFileNames: true,
+  jsxExtension: "jsx",
+  storiesFolder: ".stories"
 };
 
 /**

--- a/lib/generators/action.js
+++ b/lib/generators/action.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import {
   _generate, _generateTest, updateIndexFile, ensureModuleNameProvided,
   ensureModuleExists, removeFromIndexFile, removeFile, getOutputPath,
-  getTestOutputPath
+  getTestOutputPath,
+  getFile, getFileName
 } from './utils';
 import {getConfig} from '../config_utils';
 
@@ -19,7 +20,7 @@ export function generateAction(name, options, customConfig) {
     updateIndexFile({
       indexFilePath: `./${config.modulesPath}/${moduleName}/actions/index.js`,
       exportBeginning: 'export default {',
-      insertImport: `import ${entityName} from './${_.snakeCase(entityName)}';`,
+      insertImport: `import ${entityName} from './${getFileName(customConfig, entityName)}';`,
       insertExport: `  ${entityName}`,
       commaDelimited: true
     });
@@ -37,5 +38,5 @@ export function destroyAction(name, options, customConfig) {
 
   removeFile(getOutputPath(customConfig, 'action', entityName, moduleName));
   removeFile(getTestOutputPath('action', entityName, moduleName));
-  removeFromIndexFile(`./${config.modulesPath}/${moduleName}/actions/index.js`, entityName);
+  removeFromIndexFile(`./${config.modulesPath}/${moduleName}/actions/index.js`, entityName, customConfig);
 }

--- a/lib/generators/collection.js
+++ b/lib/generators/collection.js
@@ -1,4 +1,4 @@
-import { _generate, updateIndexFile, removeFromIndexFile, removeFile, getOutputPath } from './utils';
+import { _generate, updateIndexFile, removeFromIndexFile, removeFile, getOutputPath, getFileName, pascalCase } from './utils';
 import { getLineBreak } from '../utils';
 import shelljs from 'shelljs/shell';
 import fs from 'fs';
@@ -9,13 +9,13 @@ import {getConfig} from '../config_utils';
 export function generateCollection(name, options, customConfig) {
   const config = getConfig(customConfig);
   const {exists} = _generate('collection', null, name, options, config);
-
+  const entityName = pascalCase(name);
   if (!exists) {
     updateIndexFile({
       indexFilePath: `./lib/collections/index.js`,
       exportBeginning: 'export {',
-      insertImport: `import ${_.upperFirst(_.camelCase(name))} from './${_.snakeCase(name)}';`,
-      insertExport: `  ${_.upperFirst(_.camelCase(name))}`,
+      insertImport: `import ${entityName} from './${getFileName(customConfig, entityName)}';`,
+      insertExport: `  ${entityName}`,
       commaDelimited: true
     });
   }
@@ -42,5 +42,5 @@ export function generateCollection(name, options, customConfig) {
 export function destroyCollection(name, options, customConfig) {
   removeFile(getOutputPath(customConfig, 'collection', name));
 
-  removeFromIndexFile(`./lib/collections/index.js`, name, { capitalizeVarName: true });
+  removeFromIndexFile(`./lib/collections/index.js`, name, { capitalizeVarName: true }, customConfig);
 }

--- a/lib/generators/container.js
+++ b/lib/generators/container.js
@@ -1,6 +1,6 @@
 import {
   _generate, _generateTest, ensureModuleNameProvided, ensureModuleExists,
-  removeFromIndexFile, removeFile, getOutputPath, getTestOutputPath
+  removeFile, getOutputPath, getTestOutputPath
 } from './utils';
 import {getConfig} from '../config_utils';
 import {generateStorybook, destroyStorybook} from './storybook';

--- a/lib/generators/method.js
+++ b/lib/generators/method.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {_generate, updateIndexFile, removeFromIndexFile, removeFile, getOutputPath} from './utils';
+import {_generate, updateIndexFile, removeFromIndexFile, removeFile, getOutputPath, getFileName} from './utils';
 import {getConfig} from '../config_utils';
 
 export function generateMethod(name, options, customConfig) {
@@ -10,7 +10,7 @@ export function generateMethod(name, options, customConfig) {
     updateIndexFile({
       indexFilePath: `./server/methods/index.js`,
       exportBeginning: 'export default function () {',
-      insertImport: `import ${name} from './${_.snakeCase(name)}';`,
+      insertImport: `import ${name} from './${getFileName(customConfig, name)}';`,
       insertExport: `  ${name}();`
     });
   }
@@ -19,6 +19,6 @@ export function generateMethod(name, options, customConfig) {
 export function destroyMethod(name, options, customConfig) {
   removeFile(getOutputPath(customConfig, 'method', name));
 
-  removeFromIndexFile(`./server/methods/index.js`, name);
+  removeFromIndexFile(`./server/methods/index.js`, name, customConfig);
 
 }

--- a/lib/generators/module.js
+++ b/lib/generators/module.js
@@ -34,9 +34,9 @@ export function generateModule(name, options, customConfig = {}) {
   createFile(`${templatesPath}/client/modules/core/routes.tt`,
     `${modulePath}/routes.${config.jsxExtension}`);
   if(name === 'core') {
-    createFile(`${templatesPath}/client/modules/core/components/main_layout.${config.jsxExtension}`,
+    createFile(`${templatesPath}/client/modules/core/components/main_layout.jsx`,
            `${modulePath}/components/main_layout.${config.jsxExtension}`);
-     createFile(`${templatesPath}/client/modules/core/components/home.${config.jsxExtension}`,
+     createFile(`${templatesPath}/client/modules/core/components/home.jsx`,
             `${modulePath}/components/home.${config.jsxExtension}`);
   }
 

--- a/lib/generators/module.js
+++ b/lib/generators/module.js
@@ -32,12 +32,12 @@ export function generateModule(name, options, customConfig = {}) {
   createFile(`${templatesPath}/client/modules/core/index.js`,
     `${modulePath}/index.js`);
   createFile(`${templatesPath}/client/modules/core/routes.tt`,
-    `${modulePath}/routes.jsx`);
+    `${modulePath}/routes.${config.jsxExtension}`);
   if(name === 'core') {
-    createFile(`${templatesPath}/client/modules/core/components/main_layout.jsx`,
-           `${modulePath}/components/main_layout.jsx`);
-     createFile(`${templatesPath}/client/modules/core/components/home.jsx`,
-            `${modulePath}/components/home.jsx`);
+    createFile(`${templatesPath}/client/modules/core/components/main_layout.${config.jsxExtension}`,
+           `${modulePath}/components/main_layout.${config.jsxExtension}`);
+     createFile(`${templatesPath}/client/modules/core/components/home.${config.jsxExtension}`,
+            `${modulePath}/components/home.${config.jsxExtension}`);
   }
 
   // Modify client/main.js to import and load the newly generated module
@@ -85,7 +85,7 @@ export function generateModule(name, options, customConfig = {}) {
   });
 
   if (config.storybook) {
-    const moduleStoriesDir = `${modulePath}/components/.stories`;
+    const moduleStoriesDir = `${modulePath}/components/${config.storiesFolder}`;
     const moduleStoriesIndex = `${moduleStoriesDir}/index.js`;
     addToStorybookConfig({storybookConfigFile, moduleStoriesIndex, config});
     createDir(moduleStoriesDir);
@@ -123,7 +123,7 @@ export function destroyModule(name, options, customConfig) {
 
   const storybookConfigFile = `.storybook/config.js`;
   if (checkFileExists(storybookConfigFile)) {
-    const moduleStoriesIndex = `${modulePath}/components/.stories/index.js`;
+    const moduleStoriesIndex = `${modulePath}/components/${config.storiesFolder}/index.js`;
     removeFromStorybookConfig({storybookConfigFile, moduleStoriesIndex});
   }
   const clientDir = "./client";

--- a/lib/generators/publication.js
+++ b/lib/generators/publication.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {_generate, updateIndexFile, removeFromIndexFile, removeFile, getOutputPath} from './utils';
+import {_generate, updateIndexFile, removeFromIndexFile, removeFile, getOutputPath, getFileName} from './utils';
 import {getConfig} from '../config_utils';
 export function generatePublication(name, options, customConfig) {
   const config = getConfig(customConfig);
@@ -9,7 +9,7 @@ export function generatePublication(name, options, customConfig) {
     updateIndexFile({
       indexFilePath: `./server/publications/index.js`,
       exportBeginning: 'export default function () {',
-      insertImport: `import ${name} from './${_.snakeCase(name)}';`,
+      insertImport: `import ${name} from './${getFileName(customConfig, name)}';`,
       insertExport: `  ${name}();`
     });
   }
@@ -18,5 +18,5 @@ export function generatePublication(name, options, customConfig) {
 export function destroyPublication(name, options, customConfig) {
   removeFile(getOutputPath(customConfig, 'publication', name));
 
-  removeFromIndexFile(`./server/publications/index.js`, name);
+  removeFromIndexFile(`./server/publications/index.js`, name, customConfig);
 }

--- a/lib/generators/storybook.js
+++ b/lib/generators/storybook.js
@@ -1,14 +1,14 @@
 import _ from 'lodash';
 import {
   _generate, ensureModuleNameProvided, ensureModuleExists,
-  removeFromIndexFile, removeFile, getOutputPath, updateIndexFile
+  removeFromIndexFile, removeFile, getOutputPath, updateIndexFile,
+  getFileName
 } from './utils';
 import {getConfig} from '../config_utils';
 
 export function generateStorybook(name, options, customConfig = {}) {
   let [moduleName, entityName] = name.split(':');
   const config = getConfig(customConfig);
-  const snakeCaseName = _.snakeCase(name);
   const modulePath = `./${config.modulesPath}/${moduleName}`;
 
   ensureModuleNameProvided(name);
@@ -17,8 +17,8 @@ export function generateStorybook(name, options, customConfig = {}) {
 
   if (!exists) {
     updateIndexFile({
-      indexFilePath: `${modulePath}/components/.stories/index.js`,
-      insertImport: `import ${entityName} from './${_.snakeCase(entityName)}';`,
+      indexFilePath: `${modulePath}/components/${config.storiesFolder}/index.js`,
+      insertImport: `import './${getFileName(customConfig, entityName)}';`,
       omitExport: true
     });
   }
@@ -27,12 +27,11 @@ export function generateStorybook(name, options, customConfig = {}) {
 export function destroyStorybook(name, options, customConfig = {}) {
   let [moduleName, entityName] = name.split(':');
   const config = getConfig(customConfig);
-  const snakeCaseName = _.snakeCase(name);
   const modulePath = `${config.modulesPath}/${moduleName}`;
 
   ensureModuleNameProvided(name);
   ensureModuleExists(moduleName, customConfig);
   const storyFile = getOutputPath(customConfig, 'storybook', entityName, moduleName);
   removeFile(storyFile);
-  removeFromIndexFile(`./${modulePath}/components/.stories/index.js`, entityName);
+  removeFromIndexFile(`./${modulePath}/components/${config.storiesFolder}/index.js`, null, customConfig);
 }

--- a/lib/generators/utils.js
+++ b/lib/generators/utils.js
@@ -24,7 +24,7 @@ export function getOutputPath(customConfig, type, entityName, moduleName) {
   const config = getConfig(customConfig);
   const extensionMap = {
     action: 'js',
-    component: 'jsx',
+    component: config.jsxExtension,
     configs: 'js',
     container: 'js',
     collection: 'js',
@@ -33,7 +33,7 @@ export function getOutputPath(customConfig, type, entityName, moduleName) {
     storybook: 'js'
   };
   let extension = extensionMap[type];
-  let outputFileName = `${_.snakeCase(entityName)}.${extension}`;
+  let outputFileName = getFileName(customConfig, entityName, extension);
   const modulePath = `./${config.modulesPath}/${moduleName}`;
 
   if (type === 'collection') {
@@ -43,10 +43,18 @@ export function getOutputPath(customConfig, type, entityName, moduleName) {
   } else if (type === 'publication') {
     return `./server/publications/${outputFileName}`;
   } else if (type === 'storybook') {
-    return `${modulePath}/components/.stories/${outputFileName}`;
+    return `${modulePath}/components/${config.storiesFolder}/${outputFileName}`;
   } else {
     return `${modulePath}/${type}s/${outputFileName}`;
   }
+}
+
+export const pascalCase = _.flow(_.camelCase, _.upperFirst);
+
+export function getFileName(customConfig, entityName, extension = null) {
+  const config = getConfig(customConfig);
+  const baseName = config.snakeCaseFileNames ? _.snakeCase(entityName) : entityName;
+  return extension ? baseName+"."+extension : baseName;
 }
 
 /**
@@ -167,44 +175,45 @@ function checkForCustomTemplate(config, entityType, options) {
  * @param fileName {String} - name of the file being generated
  * @return {Object} - key-values pairs of variable names and their values
  */
-export function getTemplateVaraibles(type, moduleName, fileName, options = {}) {
+export function getTemplateVaraibles(type, moduleName, entityName, options = {}, customConfig = null) {
+
   if (type === 'component') {
     return {
       moduleName: _.snakeCase(moduleName),
-      componentName: _.upperFirst(_.camelCase(fileName))
+      componentName: pascalCase(entityName)
     };
   } else if (type === 'storybook') {
     return {
       moduleName: _.snakeCase(moduleName),
-      componentName: _.upperFirst(_.camelCase(fileName)),
-      componentFileName: _.snakeCase(fileName)
+      componentName: pascalCase(entityName),
+      componentFileName: getFileName(customConfig, entityName)
     };
   } else if (type === 'container') {
     return {
       moduleName: _.snakeCase(moduleName),
-      componentName: _.upperFirst(_.camelCase(fileName)),
-      componentFileName: _.snakeCase(fileName)
+      componentName: pascalCase(entityName),
+      componentFileName: getFileName(customConfig, entityName)
     };
   } else if (type === 'collection') {
     let variables = {
-      collectionName: _.upperFirst(_.camelCase(fileName)),
-      collectionFileName: _.snakeCase(fileName)
+      collectionName: pascalCase(entityName),
+      collectionFileName: getFileName(customConfig, entityName)
     };
 
     if (options.schema === 'astronomy') {
-      variables.className = _.upperFirst(inflect().singularize(fileName));
+      variables.className = _.upperFirst(inflect().singularize(entityName));
     }
 
     return variables;
   } else if (type === 'method') {
     return {
-      collectionName: _.upperFirst(_.camelCase(fileName)),
-      methodFileName: _.snakeCase(fileName)
+      collectionName: pascalCase(entityName),
+      methodFileName: _getFileName(customConfig, entityName)
     };
   } else if (type === 'publication') {
     return {
-      collectionName: _.upperFirst(_.camelCase(fileName)),
-      publicationFileName: _.snakeCase(fileName)
+      collectionName: pascalCase(entityName),
+      publicationFileName: getFileName(customConfig, entityName)
     };
   }
 
@@ -218,21 +227,21 @@ export function getTemplateVaraibles(type, moduleName, fileName, options = {}) {
  * @param fileName {String} - name of the file which the test is for
  * @return {Object} - key-values pairs of variable names and their values
  */
-export function getTestTemplateVaraibles(type, moduleName, fileName) {
+export function getTestTemplateVaraibles(type, moduleName, fileName, customConfig) {
   if (type === 'action') {
     return {
-      actionFileName: _.snakeCase(fileName),
+      actionFileName: getFileName(customConfig, fileName),
       moduleName: _.snakeCase(moduleName)
     };
   } else if (type === 'component') {
     return {
-      componentName: _.upperFirst(_.camelCase(fileName)),
-      componentFileName: _.snakeCase(fileName),
+      componentName: pascalCase(fileName),
+      componentFileName: getFileName(customConfig, fileName),
       moduleName: _.snakeCase(moduleName)
     };
   } else if (type === 'container') {
     return {
-      containerFileName: _.snakeCase(fileName),
+      containerFileName: getFileName(customConfig, fileName),
       moduleName: _.snakeCase(moduleName)
     };
   }
@@ -340,21 +349,24 @@ export function removeWholeLine(string, pattern) {
  * @param entityName {String} - the name of the entity whose import and export
  *        statements to be removed from the index file
  */
-export function removeFromIndexFile(indexFilePath, entityName, options = {}) {
+export function removeFromIndexFile(indexFilePath, entityName, options = {}, customConfig) {
   if (!checkFileExists(indexFilePath)) {
     logger.missing(indexFilePath);
     return;
   }
   logger.update(indexFilePath);
-  let varName = options.capitalizeVarName ?
-    _.capitalize(_.camelCase(entityName)) : _.camelCase(entityName);
-
-  let regex = new RegExp(`  ${varName}.*\n`, 'g');
-
   let content = fs.readFileSync(indexFilePath, {encoding: 'utf-8'});
-  content = removeWholeLine(content,
-    `import ${varName} from './${_.snakeCase(entityName)}';`);
-  content = removeWholeLine(content, regex);
+  if(entityName) {
+    let varName = options.capitalizeVarName ?
+      _.capitalize(_.camelCase(entityName)) : _.camelCase(entityName);
+    content = removeWholeLine(content,
+      `import ${varName} from './${getFileName(customConfig, entityName)}';`);
+    const regex = new RegExp(`  ${varName}.*\n`, 'g');
+    content = removeWholeLine(content, regex);
+  } else {
+    content = removeWholeLine(content,
+      `import './${getFileName(customConfig, entityName)}';`);
+  }
 
   outputFileSync(indexFilePath, content);
 }
@@ -406,7 +418,7 @@ export function _generate(type, moduleName, entityName, options, customConfig) {
   const config = getConfig(customConfig);
   let templateContent = readTemplateContent(type, options, config);
   let outputPath = getOutputPath(customConfig, type, entityName, moduleName);
-  let templateVariables = getTemplateVaraibles(type, moduleName, entityName, options);
+  let templateVariables = getTemplateVaraibles(type, moduleName, entityName, options, customConfig);
   let component = compileTemplate(templateContent, templateVariables, config);
 
   if (checkFileExists(outputPath)) {
@@ -422,7 +434,7 @@ export function _generate(type, moduleName, entityName, options, customConfig) {
 export function _generateTest(type, moduleName, entityName, config) {
   let templateContent = readTemplateContent(type, {testTemplate: true}, config);
   let outputPath = getTestOutputPath(type, entityName, moduleName);
-  let templateVariables = getTestTemplateVaraibles(type, moduleName, entityName);
+  let templateVariables = getTestTemplateVaraibles(type, moduleName, entityName, config);
   let component = _.template(templateContent)(templateVariables);
 
   if (checkFileExists(outputPath)) {

--- a/lib/generators/utils.js
+++ b/lib/generators/utils.js
@@ -208,7 +208,7 @@ export function getTemplateVaraibles(type, moduleName, entityName, options = {},
   } else if (type === 'method') {
     return {
       collectionName: pascalCase(entityName),
-      methodFileName: _getFileName(customConfig, entityName)
+      methodFileName: getFileName(customConfig, entityName)
     };
   } else if (type === 'publication') {
     return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantra-cli",
-  "version": "0.5.0beta.4",
+  "version": "0.6.0beta.0",
   "description": "Command line interface for building Meteor apps with Mantra",
   "bin": {
     "mantra": "./bin/mantra"


### PR DESCRIPTION
I just started a react-native app and wanted to use the mantra-cli to create components and storybook-stories, which basically works, but you need to adjust some stuff. (e.g. jsx extension is not working)

so I added new options. See https://github.com/mantrajs/mantra-cli/compare/master...panter:develop?expand=1#diff-8db911969671fc0210537a82b5f3c650

It's work in progress and not tested yet properly. E.g. module creation is not yet finished.

I released it under the beta tag: npm install -g mantra-cli@beta